### PR TITLE
Address Fixnum error

### DIFF
--- a/ficus.gemspec
+++ b/ficus.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'simplecov'

--- a/lib/ficus.rb
+++ b/lib/ficus.rb
@@ -17,7 +17,7 @@ class Ficus
 
   TYPES = {
     string:  [String],
-    number:  [Fixnum, Float],
+    number:  [Integer, Float],
     boolean: [TrueClass, FalseClass],
     array:   [Array],
     section: [Hash],


### PR DESCRIPTION
Address the following error in our use of `ruby-ficus`:

```
NameError:  uninitialized constant Ficus::Fixnum
```